### PR TITLE
Avoid crashes on *nix systems. Fix #4.

### DIFF
--- a/cachemoney/__main__.py
+++ b/cachemoney/__main__.py
@@ -30,6 +30,8 @@ def main() -> None:
         if output_root:
             url = urlparse(key)
             output_path = os.path.join(output_root, url.netloc, url.path.lstrip("/"))
+            if output_path[-1] == '/' or os.path.isdir(output_path):
+                continue
             os.makedirs(os.path.dirname(output_path), exist_ok=True)
             if args.decompress:
                 try:

--- a/cachemoney/simplefile.py
+++ b/cachemoney/simplefile.py
@@ -14,8 +14,8 @@ def parse_simplefile(fs: BinaryIO) -> Tuple[str, bytes]:
     header = fs.read(8)
     assert header == INITIAL_MAGIC
     version, key_length, key_hash, dummy = struct.unpack("<IIII", fs.read(16))
-    key = fs.read(key_length)
+    key = fs.read(key_length).decode("UTF-8").split(' ')[-1]
     data_with_trailer = fs.read()  # hardly optimal
     data, _, trailer = data_with_trailer.partition(FINAL_MAGIC)
     assert trailer
-    return (key.decode("UTF-8"), data)
+    return (key, data)


### PR DESCRIPTION
It appears that cachemoney was developed on Windows and that Windows and *nix likely have a different "key" format.

This patch avoided crashes such as #4 for me on linux, but I wouldn't be surprised if it breaks on Windows. I'm not motivated to investigate this further at the moment but I thought I'd push this as a reference for what changes would need to be made to support *nix and a workaround for *nix folks in the meantime.